### PR TITLE
Implement .extract_seed method for PcgEngine.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,6 +335,20 @@ impl<Itype, Xtype, MulMix, OutMix> SeedableRng<[Itype;2]> for PcgEngine<Itype, X
     }
 }
 
+impl<Itype, Xtype, MulMix, OutMix> PcgEngine<Itype, Xtype, SpecificSeqStream<Itype>, MulMix, OutMix>
+    where Itype: PcgOps + BitSize + Clone,
+    Xtype: PcgOps + BitSize,
+    MulMix: Multiplier<Itype>,
+    OutMix: OutputMixin<Itype, Xtype>,
+    SpecificSeqStream<Itype>: Stream<Itype>,
+    PcgEngine<Itype, Xtype, SpecificSeqStream<Itype>, MulMix, OutMix> : Rng
+{
+    /// Returns state of PcgEngine in form of a seed.
+    pub fn extract_seed(&self) -> [Itype; 2] {
+        [self.state.clone(), self.stream_mix.get_stream()]
+    }
+}
+
 impl<Xtype, StreamMix, MulMix, OutMix> SeedableRng<[u64;2]> for PcgEngine<u128, Xtype, StreamMix, MulMix, OutMix> 
     where Xtype: PcgOps + BitSize, StreamMix: Stream<u128>, MulMix: Multiplier<u128>, OutMix: OutputMixin<u128, Xtype>,
     PcgEngine<u128, Xtype, StreamMix, MulMix, OutMix> : Rng


### PR DESCRIPTION
This enables to extract the state of the PRNG in form of a seed.

I don't have fully wrapped my head around the types of this crate. Is this implementation sufficient for all types of PcgEngine?

Refers to issue #1