### PR TITLE
Avoid rustdoc's heuristics for doc code.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,11 +86,17 @@
 //! You can create a PCG as follows
 //!
 //! ```
+//! extern crate pcg_rand;
+//! extern crate rand;
+//!
+//! use rand::Rng;
 //! use pcg_rand::Pcg32;
+//!
+//! fn main() {
+//!     let mut pcg = Pcg32::new_unseeded();
 //! 
-//! let mut pcg = Pcg32::new_unseeded();
-//! 
-//! let x : u32 = pcg.gen();
+//!     let x : u32 = pcg.gen();
+//! }
 //! ```
 //! 
 //! The extended generators can be built in two ways, either by creating one 


### PR DESCRIPTION
By specifying a main method, it lets us have `extern crate` and
`use` play nicely.

(`cargo test --doc` should now pass.)